### PR TITLE
Add support for ForeignKey to_field

### DIFF
--- a/sql_util/aggregates.py
+++ b/sql_util/aggregates.py
@@ -99,10 +99,14 @@ class Subquery(DjangoSubquery):
         fields, model = self._get_fields_model_from_path(path, model, query.model)
         reverse = LOOKUP_SEP.join(fields)
 
+        join_field = path[0].join_field
         if model == query.model or len(path) == 1:
-            outer_ref = 'pk'
+            try:
+                outer_ref = join_field.get_related_field().name
+            except AttributeError:
+                outer_ref = 'pk'
         else:
-            outer_ref = path[0].join_field.name
+            outer_ref = join_field.name
 
         return reverse, outer_ref
 

--- a/sql_util/tests/models.py
+++ b/sql_util/tests/models.py
@@ -109,3 +109,21 @@ class Owner(models.Model):
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     pet = GenericForeignKey('content_type', 'object_id')
+
+
+# These models will make sure this works with to_field ForeignKeys
+
+class Brand(models.Model):
+    name = models.CharField(max_length=12)
+    company_id = models.IntegerField(unique=True)
+
+
+class Product(models.Model):
+    num_purchases = models.IntegerField()
+    brand = models.ForeignKey(
+        Brand,
+        to_field='company_id',
+        related_name='products',
+        on_delete=models.CASCADE
+    )
+


### PR DESCRIPTION
This PR adds support for `ManyToOneRel` where a custom join field is used by setting `ForeignKey.to_field`.

This is achieved by removing the hardcoded `outer_ref='pk'` and retrieve the field name by `join_field.get_related_field().name`. The caveat is that `GenericRel` does not have a `get_related_field` defined and will fallback on `pk` in this case.

I also added a test case for this.

FYI I found your project through this Django ticket https://code.djangoproject.com/ticket/28296. Maybe you're interested in bringing this into Django? :)