### PR TITLE
Fix tests and use Python 3 super methods

### DIFF
--- a/.github/workflows/mysql_test.yml
+++ b/.github/workflows/mysql_test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/mysql_test.yml
+++ b/.github/workflows/mysql_test.yml
@@ -40,9 +40,9 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/mysql_test.yml
+++ b/.github/workflows/mysql_test.yml
@@ -12,17 +12,17 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ 3.8, 3.9, 3.10.13, 3.11 ]
-        django-version: [ 3.2.21, 4.1.11, 4.2.5 ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        django-version: [ 4.2.17, 5.0.10, 5.1.4 ]
         exclude:
-          - python-version: 3.8
-            django-version: 4.1.11
-          - python-version: 3.8
-            django-version: 4.2.5
-          - python-version: 3.11
-            django-version: 3.2.21
-          - python-version: 3.11
-            django-version: 4.1.11
+          - python-version: '3.9'
+            django-version: 5.0.10
+          - python-version: '3.9'
+            django-version: 5.1.4
+          - python-version: '3.13'
+            django-version: 4.2.17
+          - python-version: '3.13'
+            django-version: 5.0.10
     services:
       mysql:
         image: mysql

--- a/.github/workflows/postgres_test.yml
+++ b/.github/workflows/postgres_test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/postgres_test.yml
+++ b/.github/workflows/postgres_test.yml
@@ -37,9 +37,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/postgres_test.yml
+++ b/.github/workflows/postgres_test.yml
@@ -12,17 +12,17 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ 3.8, 3.9, 3.10.13, 3.11 ]
-        django-version: [ 3.2.21, 4.1.11, 4.2.5 ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        django-version: [ 4.2.17, 5.0.10, 5.1.4 ]
         exclude:
-          - python-version: 3.8
-            django-version: 4.1.11
-          - python-version: 3.8
-            django-version: 4.2.5
-          - python-version: 3.11
-            django-version: 3.2.21
-          - python-version: 3.11
-            django-version: 4.1.11
+          - python-version: '3.9'
+            django-version: 5.0.10
+          - python-version: '3.9'
+            django-version: 5.1.4
+          - python-version: '3.13'
+            django-version: 4.2.17
+          - python-version: '3.13'
+            django-version: 5.0.10
     services:
       postgres:
         image: postgres

--- a/.github/workflows/sqlite_test.yml
+++ b/.github/workflows/sqlite_test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/sqlite_test.yml
+++ b/.github/workflows/sqlite_test.yml
@@ -24,9 +24,9 @@ jobs:
           - python-version: '3.13'
             django-version: 5.0.10
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/sqlite_test.yml
+++ b/.github/workflows/sqlite_test.yml
@@ -12,17 +12,17 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ 3.8, 3.9, 3.10.13, 3.11 ]
-        django-version: [ 3.2.21, 4.1.11, 4.2.5 ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        django-version: [ 4.2.17, 5.0.10, 5.1.4 ]
         exclude:
-          - python-version: 3.8
-            django-version: 4.1.11
-          - python-version: 3.8
-            django-version: 4.2.5
-          - python-version: 3.11
-            django-version: 3.2.21
-          - python-version: 3.11
-            django-version: 4.1.11
+          - python-version: '3.9'
+            django-version: 5.0.10
+          - python-version: '3.9'
+            django-version: 5.1.4
+          - python-version: '3.13'
+            django-version: 4.2.17
+          - python-version: '3.13'
+            django-version: 5.0.10
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ authors = [
 ]
 description = "Improved API for aggregating using Subquery"
 readme = "Readme.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "django>=3.2",
+    "django>=4.2",
     "sqlparse"
 ]
 

--- a/sql_util/aggregates.py
+++ b/sql_util/aggregates.py
@@ -9,7 +9,7 @@ class Subquery(DjangoSubquery):
         if isinstance(queryset_or_expression, QuerySet):
             self.queryset = queryset_or_expression
             self.query = self.queryset.query
-            super(Subquery, self).__init__(queryset_or_expression, **extra)
+            super().__init__(queryset_or_expression, **extra)
         else:
             expression = queryset_or_expression
             if not hasattr(expression, 'resolve_expression'):
@@ -34,7 +34,7 @@ class Subquery(DjangoSubquery):
             queryset = self.get_queryset(query.clone(), True, reuse, summarize)
             self.queryset = queryset
             self.query = queryset.query
-        return super(Subquery, self).resolve_expression(query, allow_joins, reuse, summarize, for_save)
+        return super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
 
     def get_queryset(self, query, allow_joins, reuse, summarize):
         # This is a customization hook for child classes to override the base queryset computed automatically
@@ -144,7 +144,7 @@ class SubqueryAggregate(Subquery):
         self.ordering = extra.pop('ordering', None)
         assert self.aggregate is not None, "Error: Attempt to instantiate a " \
                                            "SubqueryAggregate with no aggregate function"
-        super(SubqueryAggregate, self).__init__(*args, **extra)
+        super().__init__(*args, **extra)
 
     def get_queryset(self, query, allow_joins, reuse, summarize):
         queryset = self._get_base_queryset(query, allow_joins, reuse, summarize)
@@ -207,7 +207,7 @@ class SubqueryCount(SubqueryAggregate):
 
     def __init__(self, expression, reverse='', *args, **kwargs):
         kwargs['output_field'] = kwargs.get('output_field', IntegerField())
-        super(SubqueryCount, self).__init__(expression, reverse=reverse, *args, **kwargs)
+        super().__init__(expression, reverse=reverse, *args, **kwargs)
 
 
 class SubqueryMin(SubqueryAggregate):
@@ -236,7 +236,7 @@ class Exists(Subquery):
 
     def __init__(self, *args, **kwargs):
         self.negated = kwargs.pop('negated', False)
-        super(Exists, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.output_field = BooleanField()
 
     def __invert__(self):
@@ -244,7 +244,7 @@ class Exists(Subquery):
         return type(self)(self.queryset if self.queryset is not None else self.expression, negated=(not self.negated), **self.extra)
 
     def as_sql(self, compiler, connection, template=None, **extra_context):
-        sql, params = super(Exists, self).as_sql(compiler, connection, template, **extra_context)
+        sql, params = super().as_sql(compiler, connection, template, **extra_context)
         if self.negated:
             sql = 'NOT {}'.format(sql)
         return sql, params

--- a/sql_util/tests/test_exists.py
+++ b/sql_util/tests/test_exists.py
@@ -10,7 +10,7 @@ class TestExists(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestExists, cls).setUpClass()
+        super().setUpClass()
 
         parents = [
             Parent.objects.create(name='John'),
@@ -55,7 +55,7 @@ class TestExists(TestCase):
 class TestExistsFilter(TestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestExistsFilter, cls).setUpClass()
+        super().setUpClass()
         publishers = [
             Publisher.objects.create(name='Publisher 1', number=1),
             Publisher.objects.create(name='Publisher 2', number=2)
@@ -113,7 +113,7 @@ class TestManyToManyExists(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestManyToManyExists, cls).setUpClass()
+        super().setUpClass()
         publishers = [
             Publisher.objects.create(name='Publisher 1', number=1),
             Publisher.objects.create(name='Publisher 2', number=2)
@@ -219,7 +219,7 @@ class TestManyToManyExists(TestCase):
 class TestExistsReverseNames(TestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestExistsReverseNames, cls).setUpClass()
+        super().setUpClass()
         categories = [
             Category.objects.create(name='cat one'),
             Category.objects.create(name='cat two'),
@@ -292,7 +292,7 @@ class TestExistsReverseNames(TestCase):
 class TestGenericForeignKey(TestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestGenericForeignKey, cls).setUpClass()
+        super().setUpClass()
         dogs = [
             Dog.objects.create(name="Fido"),
             Dog.objects.create(name="Snoopy"),

--- a/sql_util/tests/test_postgres_settings.py
+++ b/sql_util/tests/test_postgres_settings.py
@@ -2,7 +2,7 @@ BACKEND = 'postgres'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'sqlutil',
         'USER': 'postgres',
         'PASSWORD': 'postgres',

--- a/sql_util/tests/test_subquery.py
+++ b/sql_util/tests/test_subquery.py
@@ -13,7 +13,7 @@ class TestParentChild(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestParentChild, cls).setUpClass()
+        super().setUpClass()
         parents = [
             Parent.objects.create(name='John'),
             Parent.objects.create(name='Jane')
@@ -96,7 +96,7 @@ class TestManyToMany(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestManyToMany, cls).setUpClass()
+        super().setUpClass()
         publishers = [
             Publisher.objects.create(name='Publisher 1', number=1),
             Publisher.objects.create(name='Publisher 2', number=2)
@@ -220,7 +220,7 @@ class TestManyToMany(TestCase):
 class TestForeignKey(TestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestForeignKey, cls).setUpClass()
+        super().setUpClass()
         publishers = [
             Publisher.objects.create(name='Publisher 1', number=1),
             Publisher.objects.create(name='Publisher 2', number=2)
@@ -271,7 +271,7 @@ class TestReverseForeignKey(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestReverseForeignKey, cls).setUpClass()
+        super().setUpClass()
         catalogs = [
             Catalog.objects.create(number='A'),
             Catalog.objects.create(number='B')
@@ -366,7 +366,7 @@ class TestForeignKeyToField(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestForeignKeyToField, cls).setUpClass()
+        super().setUpClass()
         brand = Brand.objects.create(name='Python', company_id=1337)
         products = [
             Product.objects.create(brand=brand, num_purchases=1),
@@ -384,7 +384,7 @@ class TestMultipleForeignKeyToTheSameModel(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestMultipleForeignKeyToTheSameModel, cls).setUpClass()
+        super().setUpClass()
 
         player1 = Player.objects.create(nickname='Player 1')
         player2 = Player.objects.create(nickname='Player 2')


### PR DESCRIPTION
- Updates test matrix to target supported versions of Django (4.2-5.1) and Python (3.9-3.13)
- Run GitHub tests on all PRs
- Update GitHub actions to resolve deprecation warnings
- Use python 3 super methods
- Use correct database backend for postgres tests
